### PR TITLE
Use markdown-it-attrs to use bootstrap responsive image class

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -5,6 +5,7 @@ const pluginSyntaxHighlight = require("@11ty/eleventy-plugin-syntaxhighlight");
 const pluginNavigation = require("@11ty/eleventy-navigation");
 const markdownIt = require("markdown-it");
 const markdownItAnchor = require("markdown-it-anchor");
+const markdownItAttrs = require("markdown-it-attrs");
 
 module.exports = function(eleventyConfig) {
   eleventyConfig.addPlugin(pluginRss);
@@ -49,6 +50,11 @@ module.exports = function(eleventyConfig) {
     permalink: true,
     permalinkClass: "direct-link",
     permalinkSymbol: "#"
+  }).use(markdownItAttrs, {
+    // optional, these are default options
+    leftDelimiter: '{',
+    rightDelimiter: '}',
+    allowedAttributes: []  // empty array = all attributes are allowed
   });
   eleventyConfig.setLibrary("md", markdownLibrary);
 

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   },
   "dependencies": {
     "bootstrap": "^4.5.0",
+    "markdown-it-attrs": "^3.0.3",
     "prismjs": "^1.20.0"
   }
 }

--- a/posts/2020-06-29-jamstack-conf-virtual-may-2020.md
+++ b/posts/2020-06-29-jamstack-conf-virtual-may-2020.md
@@ -9,7 +9,7 @@ This week I attended my first ever virtual conference. I had fairly low expectat
 
 The Jamstack conference was hosted on a platform called [Hopin](https://hopin.to/) and I have to say this platform was just outstanding. It handled over 3000 attendees without a hitch and provides live chat facilities, a stage for the main conference speakers, breakout areas for exhibitor booths and for live Q&A sessions, and a networking area where you can have a 3 minute video call with another random attendee (the equivalent of meeting in the hallway!).
 
-![](/images/uploads/harperreed.png)
+![Harper Reed](/images/uploads/harperreed.png){.img-fluid}
 
 
 
@@ -35,7 +35,7 @@ The Jamstack is a stack for modern web development, involving Javascript, APIs, 
 * I was amazed at the sheer amount and types of websites that are developed using the Jamstack. For example, did you know that the Obama presidential campaign raised $250m dollars using a Jamstack website, or that the [Covid-19 tracking project](https://covidtracking.com/) is also a Jamstack site that now serves millions of users per day?
 * The most interesting talk for me was a presentation of results from a survey of over 3000 Jamstack users. In this survey I learned how the tools we're using for our current docs-as-code implementation compare to the other tools available in terms of popularity and satisfaction.
 
-![](/images/uploads/2020-05-27_15-00-08.png)
+![Jamstack tools survey](/images/uploads/2020-05-27_15-00-08.png){.img-fluid}
 
 
 
@@ -43,7 +43,7 @@ The takeaway quote for me was this one:
 
 > Today we make it work. Tomorrow we make it look pretty.
 
-![](/images/uploads/covid19.png)
+![Covid project quote](/images/uploads/covid19.png){.img-fluid}
 
 This was from one of the volunteers on the Covid tracking project. I will definitely try to apply this to my work from now on as I often find that we spend a lot of time discussing and sharing opinions on how something looks, when all users really want is something that works!
 


### PR DESCRIPTION
- Install markdown-it-attrs npm package
- Modify eleventy config to use it with markdown (https://www.11ty.dev/docs/languages/markdown/)
- Update blogs to apply bootstrap img-fluid class to images